### PR TITLE
Add profiles to go-cover func and bug fixes

### DIFF
--- a/cover.go
+++ b/cover.go
@@ -303,6 +303,26 @@ func BlockListToGoCover(blockList [][]CoverBlock, out io.Writer, mode string) {
 	}
 }
 
+// ProfilesToGoCover convert a profile list into a go-cover file which can be interpreted by `go tool cover`.
+// `mode` value can be `set` or `count`, see `go tool cover -h` for details.
+func ProfilesToGoCover(profiles []*cover.Profile, out io.Writer, mode string) {
+	fmt.Fprintln(out, "mode:", mode)
+	for _, profile := range profiles {
+		for _, block := range profile.Blocks {
+			fmt.Fprintf(out,
+				"%s:%d.%d,%d.%d %d %d\n",
+				profile.FileName,
+				block.StartLine,
+				block.StartCol,
+				block.EndLine,
+				block.EndCol,
+				block.NumStmt,
+				block.Count,
+			)
+		}
+	}
+}
+
 // BlockListToHTML converts a block-list into a HTML coverage report.
 func BlockListToHTML(blockList [][]CoverBlock, out io.Writer, mode string) error {
 	var buf bytes.Buffer

--- a/pkg/cparser/ast.go
+++ b/pkg/cparser/ast.go
@@ -32,7 +32,9 @@ func (n *BaseNode) GetHead() lexer.Position {
 
 // BaseNode sets the positions of the first character, it takes the position from the given token
 func (n *BaseNode) SetHead(token *lexer.Token) {
-	n.Head = token.Pos
+	if token != nil {
+		n.Head = token.Pos
+	}
 }
 
 // GetTail returns the position of the last character of a node
@@ -42,8 +44,10 @@ func (n *BaseNode) GetTail() lexer.Position {
 
 // BaseNode sets the positions of the last character, it takes the position from the given token and adds its length
 func (n *BaseNode) SetTail(token *lexer.Token) {
-	n.Tail = token.Pos
-	n.Tail.Advance(token.Value)
+	if token != nil {
+		n.Tail = token.Pos
+		n.Tail.Advance(token.Value)
+	}
 }
 
 // TranslationUnit is a full file containing C code.

--- a/pkg/cparser/parser.go
+++ b/pkg/cparser/parser.go
@@ -30,7 +30,7 @@ var cLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: tokenOctalNumber, Pattern: `0[0-7]+`},
 	{Name: tokenNumber, Pattern: `[-+]?(\d*\.)?\d+`},
 	{Name: tokenIdent, Pattern: `[a-zA-Z_]\w*`},
-	{Name: tokenPunct, Pattern: `[-[!@#$%^&*()+_={}\|:;"'<,>.?/~]|]`},
+	{Name: tokenPunct, Pattern: `[-[!@#$%^&*()+_={}\|:;"'<,>.?\\/~]|]`},
 	{Name: tokenEscapedEOL, Pattern: `\\[\n\r]+`},
 	{Name: tokenEOL, Pattern: `[\n\r]+`},
 	{Name: tokenWhitespace, Pattern: `[ \t]+`},

--- a/pkg/cparser/parser.go
+++ b/pkg/cparser/parser.go
@@ -80,6 +80,9 @@ func (tl *TokenList) PeekN(n int) *lexer.Token {
 	if len(*tl) <= n {
 		return nil
 	}
+	if n < 0 {
+		return nil
+	}
 
 	return &(*tl)[n]
 }
@@ -372,6 +375,11 @@ func (p *Parser) parseExternalDeclaration(tokens TokenList) (*ExternalDeclaratio
 	last := tokens.PeekTail()
 	if last == nil {
 		return nil, fmt.Errorf("no last token")
+	}
+
+	// Discard trailing tokens.
+	if last.EOF() {
+		return nil, nil
 	}
 
 	var extDecl ExternalDeclaration


### PR DESCRIPTION
The changes in this change set were discovered while integrating coverbee with Cilium. They include a function to convert cover profiles to a gp-cover file instead of only to HTML, and a few bug fixes which caused panics and errors.