### PR TITLE
Fixed null check return code to support socket programs

### DIFF
--- a/instrumentation.go
+++ b/instrumentation.go
@@ -206,13 +206,14 @@ func InstrumentAndLoadCollection(
 					// 5. Lookup map value
 					asm.FnMapLookupElem.Call(),
 					// 6. Null check (exit on R0 = null)
+					//    Note: Exit with code 1, some program types have restrictions on return values.
 					asm.Instruction{
 						OpCode:   asm.OpCode(asm.JumpClass).SetJumpOp(asm.JNE).SetSource(asm.ImmSource),
 						Dst:      asm.R0,
 						Offset:   2,
 						Constant: 0,
 					},
-					asm.Mov.Imm(asm.R0, -1),
+					asm.Mov.Imm(asm.R0, 1),
 					asm.Return(),
 					// 7. Store map value on in coverMapFPOff
 					asm.StoreMem(asm.R10, -int16(coverMapPFOff), asm.R0, asm.DWord),


### PR DESCRIPTION
The instrumented code will set R0 to a return value and then exit the
program as a bounds check, which is required by the verifier. However,
the value we were using was `-1`, this is not an issue for most programs
but the verifier has logic to disallow undefined return codes from some
program types. So we changed the return value to `1` which seems to be
accepted everywhere.