### PR TITLE
Fixed handling of dead code

### DIFF
--- a/pkg/verifierlog/verifierlog.go
+++ b/pkg/verifierlog/verifierlog.go
@@ -37,6 +37,8 @@ func MergedPerInstruction(log string) []VerifierState {
 	var curState VerifierState
 
 	mergeCurState := func(state VerifierState) {
+		curState.Unknown = false
+
 		for _, reg := range state.Registers {
 			found := false
 			for i, curReg := range curState.Registers {
@@ -68,11 +70,17 @@ func MergedPerInstruction(log string) []VerifierState {
 
 	applyCurState := func(instNum int) {
 		if instNum >= len(states) {
-			states = append(states, make([]VerifierState, 1+instNum-len(states))...)
+			newStates := make([]VerifierState, 1+instNum-len(states))
+			for i := range newStates {
+				newStates[i].Unknown = true
+			}
+			states = append(states, newStates...)
 		}
 
 		// Apply current state to `states`
 		for _, curReg := range curState.Registers {
+			states[instNum].Unknown = false
+
 			found := false
 			for i, reg := range states[instNum].Registers {
 				if reg.Register == curReg.Register {
@@ -470,6 +478,8 @@ type VerifierState struct {
 	FrameNumber int
 	Registers   []RegisterState
 	Stack       []StackState
+	// If true, the struct was initialized as filler, but no actual state info is known
+	Unknown bool
 }
 
 func parseRegisterState(key, value string) (*RegisterState, error) {
@@ -509,7 +519,12 @@ func parseRegisterState(key, value string) (*RegisterState, error) {
 }
 
 func (is *VerifierState) String() string {
+	if is.Unknown {
+		return "unknown"
+	}
+
 	var sb strings.Builder
+
 	if is.FrameNumber != 0 {
 		fmt.Fprintf(&sb, "frame%d: ", is.FrameNumber)
 	}
@@ -1490,10 +1505,11 @@ func parseFunctionCall(firstLine string, scan *bufio.Scanner) VerifierStatement 
 // FunctionCall indicates the verifier is following a bpf-to-bpf function call.
 // For example:
 // caller:
-//   frame1: R6=pkt(id=0,off=54,r=74,imm=0) R7=pkt(id=0,off=0,r=74,imm=0) R8_w=pkt(id=0,off=74,r=74,imm=0) R9=invP6
-//   R10=fp0 fp-8=pkt_end fp-16=mmmmmmmm
-//  callee:
-//   frame2: R1_w=pkt(id=0,off=54,r=74,imm=0) R2_w=invP(id=0) R10=fp0
+//
+//	 frame1: R6=pkt(id=0,off=54,r=74,imm=0) R7=pkt(id=0,off=0,r=74,imm=0) R8_w=pkt(id=0,off=74,r=74,imm=0) R9=invP6
+//	 R10=fp0 fp-8=pkt_end fp-16=mmmmmmmm
+//	callee:
+//	 frame2: R1_w=pkt(id=0,off=54,r=74,imm=0) R2_w=invP(id=0) R10=fp0
 type FunctionCall struct {
 	CallerState *VerifierState
 	CalleeState *VerifierState
@@ -1550,10 +1566,13 @@ func parseReturnFunctionCall(firstLine string, scan *bufio.Scanner) VerifierStat
 // ReturnFunctionCall indicates the verifier is evaluating returning from a function call.
 // Example:
 // returning from callee:
-//  frame2: R0=map_value(id=0,off=0,ks=1,vs=16,imm=0) R1_w=invP(id=0) R6=invP(id=31) R10=fp0 fp-8=m???????
+//
+//	frame2: R0=map_value(id=0,off=0,ks=1,vs=16,imm=0) R1_w=invP(id=0) R6=invP(id=31) R10=fp0 fp-8=m???????
+//
 // to caller at 156:
-//   frame1: R0=map_value(id=0,off=0,ks=1,vs=16,imm=0) R6=pkt(id=0,off=54,r=54,imm=0) R7=pkt(id=0,off=0,r=54,imm=0)
-//   R8=invP14 R9=invP(id=30,umax_value=255,var_off=(0x0; 0xff)) R10=fp0 fp-8=pkt_end fp-16=mmmmmmmm
+//
+//	frame1: R0=map_value(id=0,off=0,ks=1,vs=16,imm=0) R6=pkt(id=0,off=54,r=54,imm=0) R7=pkt(id=0,off=0,r=54,imm=0)
+//	R8=invP14 R9=invP(id=30,umax_value=255,var_off=(0x0; 0xff)) R10=fp0 fp-8=pkt_end fp-16=mmmmmmmm
 type ReturnFunctionCall struct {
 	CallerState *VerifierState
 	CallSite    int


### PR DESCRIPTION
There were two situations involving dead code that coverbee did not handle well. If the last part of a program contained dead code, the list of merged states would be shorter than the list of instructions since the verifier log never covered that part, causing a panic.

The second situation would be when there is dead code in the middle of a program. In which case we would only have a "blank" state, and we would start using registers which might already be in use.

If one of these situations is detected, we will still instrument the program but assume we have no registers available which is the worst case but also always save.