### PR TITLE
verifierlog: Fixed edge case where empty state values were not parsed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
       - name: checkout code
         uses: actions/checkout@v2
       - name: Run linters
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.46.2
+          version: v1.51.2
           args: --config=.golangci.yml
       - name: Install revive
         run: go install github.com/mgechev/revive@v1.1.3

--- a/cover.go
+++ b/cover.go
@@ -360,16 +360,23 @@ func BlockListFilePaths(blockList [][]CoverBlock) []string {
 
 // Check for:
 // aaaaa
-//   bbbbb
+//
+//	bbbbb
+//
 // -----
-//    aaaa
+//
+//	aaaa
+//
 // bbbb
 // -----
-//   aaa
+//
+//	aaa
+//
 // bbbbbbb
 // -----
 // aaaaaaa
-//   bbb
+//
+//	bbb
 func blocksOverlap(a, b cover.ProfileBlock) bool {
 	return (blockLTE(a.StartLine, a.StartCol, b.EndLine, b.EndCol) &&
 		blockGTE(a.EndLine, a.EndCol, b.EndLine, b.EndCol)) ||

--- a/pkg/verifierlog/verifierlog.go
+++ b/pkg/verifierlog/verifierlog.go
@@ -418,34 +418,34 @@ func parseVerifierState(line string) (*VerifierState, error) {
 		var value string
 
 		line = line[equal+1:]
-		if len(line) == 0 {
-			break
-		}
+		// If there are chars left after '=' find the end of the current value.
+		// If not, the current key may not have a value (R1=) which is also valid.
+		if len(line) > 1 {
+			bktDepth := 0
+			i := 0
+			for {
+				i++
+				if i >= len(line) {
+					value = line
+					line = line[i:]
+					break
+				}
 
-		bktDepth := 0
-		i := 0
-		for {
-			i++
-			if i >= len(line) {
-				value = line
-				line = line[i:]
-				break
-			}
+				if line[i] == '(' {
+					bktDepth++
+					continue
+				}
 
-			if line[i] == '(' {
-				bktDepth++
-				continue
-			}
+				if line[i] == ')' {
+					bktDepth--
+					continue
+				}
 
-			if line[i] == ')' {
-				bktDepth--
-				continue
-			}
-
-			if line[i] == ' ' && bktDepth == 0 {
-				value = line[:i]
-				line = line[i+1:]
-				break
+				if line[i] == ' ' && bktDepth == 0 {
+					value = line[:i]
+					line = line[i+1:]
+					break
+				}
 			}
 		}
 


### PR DESCRIPTION
The verifier log parser did not handle the edge case where the last state in a verifier state section has no value. Like: `R1_w=scalar(umax=1,var_off=(0x0; 0x1)) R10=fp0 fp-240_w=`

This caused the parser to not include the stack slot for -240, which in turn causes the instrumentation of some programs to go wrong.